### PR TITLE
Fix invalid use of reserved identifier

### DIFF
--- a/libinotifytools/src/test.c
+++ b/libinotifytools/src/test.c
@@ -5,7 +5,6 @@
 
 #include "../../config.h"
 
-#define __USE_MISC
 #include <unistd.h>
 
 #include <stdio.h>


### PR DESCRIPTION
Identifiers starting with __ are reserved for the implementation and must
not be defined by the application.
