### PR TITLE
correct code alignment

### DIFF
--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -122,9 +122,9 @@ void validate_format( char * fmt ) {
 
 
 void output_event_csv( struct inotify_event * event ) {
-    char *filename = csv_escape(inotifytools_filename_from_wd(event->wd));
-    if (filename != NULL)
-        printf("%s,", filename);
+	char *filename = csv_escape(inotifytools_filename_from_wd(event->wd));
+	if (filename != NULL)
+		printf("%s,", filename);
 
 	printf("%s,", csv_escape( inotifytools_event_to_str( event->mask ) ) );
 	if ( event->len > 0 )


### PR DESCRIPTION
The following replaces the indented section of code from spaces to tabs.
No functional changes. Aside from consistency, this resolves a GCC 6
build issue with the flag `-Werror=misleading-indentation` enabled:

```
inotifywait.c: In function ‘output_event_csv’:
inotifywait.c:126:5: error: this ‘if’ clause does not guard...
                            [-Werror=misleading-indentation]
     if (filename != NULL)
     ^~
inotifywait.c:129:2: note: ...this statement, but the latter is
                           misleadingly indented as if it is guarded
                           by the ‘if’
  printf("%s,", csv_escape( inotifytools_event_to_str( event->mask )
                                                                ) );
  ^~~~~~
```

Signed-off-by: James Knight james.d.knight@live.com
