### PR TITLE
inotifywait: fix compile error with GCC 6

### DIFF
--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -122,9 +122,9 @@ void validate_format( char * fmt ) {
 
 
 void output_event_csv( struct inotify_event * event ) {
-    char *filename = csv_escape(inotifytools_filename_from_wd(event->wd));
-    if (filename != NULL)
-        printf("%s,", filename);
+	char *filename = csv_escape(inotifytools_filename_from_wd(event->wd));
+	if (filename != NULL)
+		printf("%s,", filename);
 
 	printf("%s,", csv_escape( inotifytools_event_to_str( event->mask ) ) );
 	if ( event->len > 0 )


### PR DESCRIPTION
Fails to compile with misleading-indentation error

| src/inotifywait.c: In function 'output_event_csv':
| src/inotifywait.c:126:5: error: this 'if' clause does not guard... [-Werror=misleading-indentation]
|      if (filename != NULL)
|      ^~
| src/inotifywait.c:129:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
|   printf("%s,", csv_escape( inotifytools_event_to_str( event->mask ) ) );
|   ^~~~~~
| cc1: all warnings being treated as errors

Fix indentation to resolve.

Signed-off-by: Andrea Galbusera gizero@gmail.com
