### PR TITLE
Fix compilation with GCC 6+

### DIFF
--- a/src/inotifywait.c
+++ b/src/inotifywait.c
@@ -122,9 +122,10 @@ void validate_format( char * fmt ) {
 
 
 void output_event_csv( struct inotify_event * event ) {
-    char *filename = csv_escape(inotifytools_filename_from_wd(event->wd));
-    if (filename != NULL)
-        printf("%s,", filename);
+	char *filename = csv_escape(inotifytools_filename_from_wd(event->wd));
+
+	if (filename != NULL)
+		printf("%s,", filename);
 
 	printf("%s,", csv_escape( inotifytools_event_to_str( event->mask ) ) );
 	if ( event->len > 0 )


### PR DESCRIPTION
Recently GCC introduced a new warning validation: misleading indentation.
It's the option -Wmisleading-indentation, added on -Wall. So, since GCC 6
inotify-tools won't compile due to a "bad" indentation (according GCC!).

This patch just fixes the indentation of a block, making the compilation
works again.

Signed-off-by: Guilherme G. Piccoli <gpiccoli@linux.vnet.ibm.com>