### PR TITLE
Use realpath on --outfile

### DIFF
--- a/t/Makefile
+++ b/t/Makefile
@@ -42,7 +42,7 @@ pre-clean:
 	$(RM) -r test-results
 
 clean-except-prove-cache:
-	$(RM) -r 'trash directory'.* test-results
+	$(RM) -r 'trash.directory'.* test-results
 
 clean: clean-except-prove-cache
 	$(RM) .prove

--- a/t/inotifywait-daemon-logs-to-relative-paths.t
+++ b/t/inotifywait-daemon-logs-to-relative-paths.t
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+test_description='Issue #62
+
+When --daemon is used, events are logged correctly to --outfile
+even if that is a relative path
+'
+
+. ./sharness.sh
+
+logfile="log"
+
+run_() {
+    # Setup code, defer an ATTRIB event for after
+    # inotifywait has been set up.
+    timeout=2 &&
+    touch $logfile test-file &&
+    {(sleep 1 && touch -a test-file)&} &&
+
+    inotifywait \
+        --quiet \
+        --daemon \
+        --outfile $logfile \
+        --event ATTRIB \
+        --timeout $timeout \
+        $(realpath test-file) &&
+    # No way to use 'wait' for a process that is not a child of this one,
+    # sleep instead until inotifywait's timeout is reached.
+    sleep $timeout
+}
+
+test_expect_success 'event logged' '
+    run_ &&
+    grep ATTRIB $logfile
+'
+
+test_done

--- a/t/sharness.sh
+++ b/t/sharness.sh
@@ -812,7 +812,7 @@ SHARNESS_TEST_FILE="$0"
 export SHARNESS_TEST_FILE
 
 # Prepare test area.
-SHARNESS_TRASH_DIRECTORY="trash directory.$(basename "$SHARNESS_TEST_FILE" ".$SHARNESS_TEST_EXTENSION")"
+SHARNESS_TRASH_DIRECTORY="trash.directory.$(basename "$SHARNESS_TEST_FILE" ".$SHARNESS_TEST_EXTENSION")"
 test -n "$root" && SHARNESS_TRASH_DIRECTORY="$root/$SHARNESS_TRASH_DIRECTORY"
 case "$SHARNESS_TRASH_DIRECTORY" in
 /*) ;; # absolute path is good


### PR DESCRIPTION
When daemonizing, the current directory is changed, which makes
inotifwait to fail if --outfile is not provided as an absolute pathname.