### PR TITLE
Use ChangeLog date instead of build date

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,7 @@ AC_C_INLINE
 AC_CHECK_FUNCS([daemon])
 
 # Set variables used in man page templates
-MAN_DATE=$(date +'%B %d, %Y')
+MAN_DATE=$(date -u -r ChangeLog +'%Y-%m-%d')
 MAN_PACKAGE_VERSION=$PACKAGE_VERSION
 AC_SUBST([MAN_DATE])
 AC_SUBST([MAN_PACKAGE_VERSION])

--- a/configure.ac
+++ b/configure.ac
@@ -65,7 +65,7 @@ AC_C_INLINE
 AC_CHECK_FUNCS([daemon])
 
 # Set variables used in man page templates
-MAN_DATE=$(date -u -r ChangeLog +'%Y-%m-%d')
+MAN_DATE=$(date -u -r ChangeLog +'%B %d, %Y')
 MAN_PACKAGE_VERSION=$PACKAGE_VERSION
 AC_SUBST([MAN_DATE])
 AC_SUBST([MAN_PACKAGE_VERSION])


### PR DESCRIPTION
Use ChangeLog date instead of build date
in order to make (man-page) builds reproducible.
See https://reproducible-builds.org/ for why this is good.

This date call works with GNU date and BSD date.

This PR was done while working on reproducible builds for openSUSE.